### PR TITLE
Add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "homepage": "https://github.com/streetlogics/jquery.image.blob",
   "authors": [
-    "Brad Wedell <brad@massroots.com>",
     "CoeJoder"
   ],
   "description": "A simple jQuery plugin for uploading embedded images, eliminating the need to manually download and upload via form. The image is converted into a Blob and uploaded as a file.",

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "jquery.image.blob",
+  "version": "0.0.1",
+  "homepage": "https://github.com/streetlogics/jquery.image.blob",
+  "authors": [
+    "Brad Wedell <brad@massroots.com>",
+    "CoeJoder"
+  ],
+  "description": "A simple jQuery plugin for uploading embedded images, eliminating the need to manually download and upload via form. The image is converted into a Blob and uploaded as a file.",
+  "dependencies": {
+    "jquery": ">=1.6"
+  },
+  "main": "./jquery-image-blob.min.js",
+  "keywords": [
+    "jquery",
+    "image",
+    "blob"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
This PR adds a bower.json file to the project so that users can install the project via bower (ex: `bower install https://github.com/streetlogics/jquery.image.blog --save`)